### PR TITLE
Fixed sed replacement for OSX

### DIFF
--- a/test-asciidoctor-upstream.sh
+++ b/test-asciidoctor-upstream.sh
@@ -19,8 +19,8 @@ unzip -q $SRC_DIR.zip
 cp ../../asciidoctor-gem-installer.pom $SRC_DIR/pom.xml
 cd $SRC_DIR
 ASCIIDOCTOR_VERSION=`grep 'VERSION' ./lib/asciidoctor/version.rb | sed "s/.*'\(.*\)'.*/\1/"`
-sed -i "s;<version></version>;<version>$ASCIIDOCTOR_VERSION</version>;" pom.xml
-sed -i "s;^ *s\.files \+.*$;s.files = Dir['*.gemspec', '*.adoc', '{bin,data,lib}/*', '{bin,data,lib}/**/*'];" asciidoctor.gemspec
+sed "s;<version></version>;<version>$ASCIIDOCTOR_VERSION</version>;" pom.xml > pom.xml.sedtmp && mv -f pom.xml.sedtmp pom.xml
+sed "s;^ *s\.files \+.*$;s.files = Dir['*.gemspec', '*.adoc', '{bin,data,lib}/*', '{bin,data,lib}/**/*'];" asciidoctor.gemspec > asciidoctor.gemspec.sedtmp && mv -f asciidoctor.gemspec.sedtmp asciidoctor.gemspec
 mvn install -Dgemspec=asciidoctor.gemspec
 cd ../..
 #rm -rf maven

--- a/test-asciidoctor-upstream.sh
+++ b/test-asciidoctor-upstream.sh
@@ -20,7 +20,7 @@ cp ../../asciidoctor-gem-installer.pom $SRC_DIR/pom.xml
 cd $SRC_DIR
 ASCIIDOCTOR_VERSION=`grep 'VERSION' ./lib/asciidoctor/version.rb | sed "s/.*'\(.*\)'.*/\1/"`
 sed "s;<version></version>;<version>$ASCIIDOCTOR_VERSION</version>;" pom.xml > pom.xml.sedtmp && mv -f pom.xml.sedtmp pom.xml
-sed "s;^ *s\.files \+.*$;s.files = Dir['*.gemspec', '*.adoc', '{bin,data,lib}/*', '{bin,data,lib}/**/*'];" asciidoctor.gemspec > asciidoctor.gemspec.sedtmp && mv -f asciidoctor.gemspec.sedtmp asciidoctor.gemspec
+sed "s;^ *s\.files .*$;s.files = Dir['*.gemspec', '*.adoc', '{bin,data,lib}/*', '{bin,data,lib}/**/*'];" asciidoctor.gemspec > asciidoctor.gemspec.sedtmp && mv -f asciidoctor.gemspec.sedtmp asciidoctor.gemspec
 mvn install -Dgemspec=asciidoctor.gemspec
 cd ../..
 #rm -rf maven


### PR DESCRIPTION
Learned sth new about sed! :)
Didn't know that `;` can be used instead of `/` to separate elements.
The `\+` doesn't match on my machine though.

Tested on OS X and on an Ubuntu Docker container.
