### PR TITLE
Added test for isolation from system gems

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -50,3 +50,49 @@ jar {
       '*'
   }
 }
+
+test {
+  useJUnit {
+    excludeCategories 'org.asciidoctor.categories.Polluted'
+  }
+}
+
+task pollutedTest(type: Test) {
+  useJUnit {
+    includeCategories 'org.asciidoctor.categories.Polluted'
+  }
+  forkEvery = 10
+  minHeapSize = '128m'
+  maxHeapSize = '1024m'
+  if (JavaVersion.current().isJava8Compatible()) {
+    jvmArgs '-XX:-UseGCOverheadLimit'
+  }
+  else {
+    jvmArgs '-XX:MaxPermSize=256m', '-XX:-UseGCOverheadLimit'
+  }
+
+  environment 'GEM_PATH', '/some/path'
+  environment 'GEM_HOME', '/some/other/path'
+
+  testLogging {
+    // events 'passed', 'failed', 'skipped', 'standard_out', 'standard_error'
+    // events 'standard_out', 'standard_error'
+    afterSuite { desc, result ->
+      if (!desc.parent && logger.infoEnabled) {
+        logger.info "Test results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+      }
+    }
+  }
+
+  reports {
+    html {
+      destination file("$buildDir/reports/pollutedTest")
+    }
+    junitXml {
+      destination file("$buildDir/pollutedTest-result")
+    }
+  }
+}
+
+test.dependsOn pollutedTest
+

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath.java
@@ -1,0 +1,69 @@
+package org.asciidoctor;
+
+import org.asciidoctor.categories.Polluted;
+import org.asciidoctor.internal.JRubyRuntimeContext;
+import org.jruby.Ruby;
+import org.jruby.RubyString;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This test checks if the Ruby instance for an Asciidoctor instance is
+ * not affected by a GEM_HOME or GEM_PATH environment variable.
+ * It can mix up the JRuby instance when it can see gems from a C-Ruby
+ * with native extensions.
+ */
+@Category(Polluted.class)
+public class WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath {
+
+    @Test
+    public void should_not_have_gempath_in_ruby_env_when_created_with_null_gempath() {
+        // Given: Our environment is polluted (Cannot set these env vars here, so just check that gradle has set them correctly)
+        assertThat(System.getenv("GEM_PATH"), notNullValue());
+        assertThat(System.getenv("GEM_HOME"), notNullValue());
+
+        // When: A new Asciidoctor instance is created passing in a null GEM_PATH
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create((String) null);
+
+        // Then: The org.jruby.JRuby instance does not see this variable
+        Ruby rubyRuntime = JRubyRuntimeContext.get();
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), is(rubyRuntime.getNil()));
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), is(rubyRuntime.getNil()));
+    }
+
+    @Test
+    public void should_have_gempath_in_ruby_env_when_created_with_non_null_gempath() {
+        // Given: Our environment is polluted (Cannot set these env vars here, so just check that gradle has set them correctly)
+        assertThat(System.getenv("GEM_PATH"), notNullValue());
+        assertThat(System.getenv("GEM_HOME"), notNullValue());
+
+        // When: A new Asciidoctor instance is created passing in no GEM_PATH
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+
+        // Then: The org.jruby.JRuby instance sees this variable
+        Ruby rubyRuntime = JRubyRuntimeContext.get();
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), not(is(rubyRuntime.getNil())));
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), not(is(rubyRuntime.getNil())));
+    }
+
+    @Test
+    public void should_have_gempath_in_ruby_env_when_created_with_gempath() {
+        // Given: Our environment is polluted (Cannot set these env vars here, so just check that gradle has set them correctly)
+        final String gemPath = "/another/path";
+        assertThat(System.getenv("GEM_PATH"), notNullValue());
+        assertThat(System.getenv("GEM_HOME"), notNullValue());
+
+        // When: A new Asciidoctor instance is created passing in a null GEM_PATH
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create(gemPath);
+
+        // Then: The org.jruby.JRuby instance does not see this variable
+        Ruby rubyRuntime = JRubyRuntimeContext.get();
+        RubyString rubyGemPath = rubyRuntime.newString(gemPath);
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), is((Object) rubyGemPath));
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), is((Object) rubyGemPath));
+    }
+
+}


### PR DESCRIPTION
I added a new test task to the gradle build, _pollutedTest_, that executes one test with the env vars GEM_PATH and GEM_HOME set.
This test task executes all tests belonging to the JUnit category `Polluted`.
